### PR TITLE
Add energy trajectory recording feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ or by using `conda`:
 conda env create -f envinronment.yml
 ```
 
+## Recording Energy Trajectories
+
+Set `record_trajectory=True` when calling `Solver.metropolis_update` to store
+the energy of each replica after every sweep.
+
+```python
+from pysa.sa import Solver
+import matplotlib.pyplot as plt
+
+solver = Solver(problem, problem_type='ising')
+res = solver.metropolis_update(num_sweeps=100, record_trajectory=True)
+trajectory = res['energy_trajectory'][0]
+plt.plot(trajectory.min(axis=1))
+plt.xlabel('Sweep')
+plt.ylabel('Best energy')
+plt.show()
+```
+
 ## NASA Open Source Agreement and Contributions
 
 See [NOSA](https://github.com/nasa/pysa/tree/main/docs/nasa-cla/).

--- a/tests/test_energy_trajectory.py
+++ b/tests/test_energy_trajectory.py
@@ -1,0 +1,72 @@
+"""
+Copyright © 2023, United States Government, as represented by the Administrator
+of the National Aeronautics and Space Administration. All rights reserved.
+
+The PySA, a powerful tool for solving optimization problems is licensed under
+the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import numpy as np
+import pysa.simulation as simulation
+import pysa.ising as ising
+
+
+def test_record_trajectory_parallel():
+    couplings = np.array([[0, 1], [1, 0]], dtype="float")
+    local_fields = np.zeros(2, dtype="float")
+    states = 2 * np.random.randint(2, size=(1, 2)).astype("float") - 1
+    energies = np.array([
+        ising.get_energy(couplings, local_fields, state) for state in states
+    ])
+    betas = np.array([1.0], dtype="float")
+    beta_idx = np.arange(1)
+
+    (out_states, out_energies, _, _, traj), _ = simulation.simulation_parallel(
+        ising.update_spin,
+        simulation.random_sweep,
+        couplings,
+        local_fields,
+        states,
+        energies,
+        beta_idx,
+        betas,
+        5,
+        record_trajectory=True,
+    )
+
+    assert traj.shape == (5, 1)
+    assert np.isclose(traj[-1, 0], out_energies[0])
+
+
+def test_record_trajectory_sequential():
+    couplings = np.array([[0, 1], [1, 0]], dtype="float")
+    local_fields = np.zeros(2, dtype="float")
+    states = 2 * np.random.randint(2, size=(1, 2)).astype("float") - 1
+    energies = np.array([
+        ising.get_energy(couplings, local_fields, state) for state in states
+    ])
+    betas = np.array([1.0], dtype="float")
+    beta_idx = np.arange(1)
+
+    (out_states, out_energies, _, _, traj), _ = simulation.simulation_sequential(
+        ising.update_spin,
+        simulation.random_sweep,
+        couplings,
+        local_fields,
+        states,
+        energies,
+        beta_idx,
+        betas,
+        5,
+        record_trajectory=True,
+    )
+
+    assert traj.shape == (5, 1)
+    assert np.isclose(traj[-1, 0], out_energies[0])


### PR DESCRIPTION
## Summary
- extend `simulation_parallel` and `simulation_sequential` with energy trajectory recording
- allow `Solver.metropolis_update` to return energy trajectories
- document trajectory recording in README
- test trajectory capture for parallel and sequential simulations

## Testing
- `python -m pytest -q tests/test_energy_trajectory.py`

------
https://chatgpt.com/codex/tasks/task_e_6841eb7911fc8328a0d01cb0f3817290